### PR TITLE
添加MoFox Liunx部署脚本

### DIFF
--- a/MoFox-install.sh
+++ b/MoFox-install.sh
@@ -437,7 +437,7 @@ install_python_dependencies() {
 
     if [[ -f "template/bot_config_template.toml" ]]; then
         cp "template/bot_config_template.toml" "config/bot_config.toml"
-        ok "已复制 bot_config_template.toml"
+        ok "已复制 bot_config.toml"
     else
         warn "未找到 template/bot_config_template.toml"
     fi

--- a/MoFox-install.sh
+++ b/MoFox-install.sh
@@ -390,7 +390,7 @@ install_python_dependencies() {
     # 配置 uv 镜像源
     export UV_INDEX_URL="https://mirrors.ustc.edu.cn/pypi/simple/"
     mkdir -p ~/.cache/uv
-    chown -R "$(whoami):$(whoami)" ~/.cache/uv
+    chown -R "$(id -u):$(id -g)" ~/.cache/uv || warn "chown ~/.cache/uv 失败, 请检查权限"
 
     # 安装 MoFox_Bot 依赖
     cd "$DEPLOY_DIR/MoFox_Bot" || err "无法进入 MoFox_Bot 目录"

--- a/MoFox-install.sh
+++ b/MoFox-install.sh
@@ -262,7 +262,7 @@ install_package() {    #定义函数
         $SUDO apk add gcc musl-dev linux-headers "$package" #安装包
         ;;
     brew)
-        $SUDO install "$package" #安装包
+        $SUDO brew install "$package" #安装包
         ;;
     *)
         warn "未知包管理器 $PKG_MANAGER，请手动安装 $package" #打印警告

--- a/MoFox-install.sh
+++ b/MoFox-install.sh
@@ -1,0 +1,514 @@
+#!/bin/bash
+# MoFox部署脚本 2525.10.25
+set -euo pipefail
+
+get_script_dir() {
+    local source="${BASH_SOURCE[0]}"
+
+    # 检查是否来自进程替换（如 bash <(curl ...)）
+    if [[ "$source" == /dev/fd/* ]] || [[ ! -f "$source" ]]; then
+        # 无法定位真实脚本文件，使用当前工作目录
+        pwd
+    else
+        # 正常情况：解析脚本真实路径
+        (cd "$(dirname "$source")" && pwd)
+    fi
+}
+
+SCRIPT_DIR="$(get_script_dir)"
+DEPLOY_DIR="$SCRIPT_DIR"
+
+LOCAL_BIN="$HOME/.local/bin"
+
+echo "SCRIPT_DIR: $SCRIPT_DIR"
+echo "DEPLOY_DIR: $DEPLOY_DIR"
+
+# 检查是否为异常目录（如 /dev/fd、/proc/self/fd 等）
+if [[ "$DEPLOY_DIR" == /dev/fd/* ]] || [[ "$DEPLOY_DIR" == /proc/self/fd/* ]] || [[ ! -d "$DEPLOY_DIR" ]]; then
+    echo -e "\e[31m警告：检测到部署目录异常！可能因使用 'bash <(curl ...)' 导致路径错误。\e[0m"
+    echo -e "\e[33m建议：将脚本下载到本地后运行，或确保当前目录可写。\e[0m"
+else
+    echo -e "\e[32m目录正常，可安全部署。\e[0m"
+fi
+
+# 检查命令是否存在
+command_exists() {
+    command -v "$1" >/dev/null 2>&1 # 检查命令是否存在
+}
+
+# =============================================================================
+# 日志函数
+# =============================================================================
+# 定义颜色
+RESET='\033[0m'   # 重置颜色
+BOLD='\033[1m'    # 加粗
+RED='\033[31m'    # 红色
+GREEN='\033[32m'  # 绿色
+YELLOW='\033[33m' # 黄色
+BLUE='\033[34m'   # 蓝色
+CYAN='\033[36m'   # 青色
+
+# 信息日志
+info() { echo -e "${BLUE}[INFO]${RESET} $1"; }
+
+# 成功日志
+ok() { echo -e "${GREEN}[OK]${RESET} $1"; }
+
+# 警告日志
+warn() { echo -e "${YELLOW}[WARN]${RESET} $1"; }
+
+# 错误日志
+err() {
+    echo -e "${RED}[ERROR]${RESET} $1"
+    exit 1
+}
+
+# 打印标题
+print_title() { echo -e "${BOLD}${CYAN}=== $1 ===${RESET}"; }
+
+download_with_retry() {  #定义函数
+    local url="$1"       #获取参数
+    local output="$2"    #获取参数
+    local max_attempts=3 #最大尝试次数
+    local attempt=1      #当前尝试次数
+
+    while [[ $attempt -le $max_attempts ]]; do               #循环直到达到最大尝试次数
+        info "下载尝试 $attempt/$max_attempts: $url"             #打印信息日志
+        if command_exists wget; then                         #如果 wget 存在
+            if wget -O "$output" "$url" 2>/dev/null; then    #使用 wget 下载
+                ok "下载成功: $output"                           #打印日志
+                return 0                                     #成功返回
+            fi                                               #结束条件判断
+        elif command_exists curl; then                       #如果 curl 存在
+            if curl -L -o "$output" "$url" 2>/dev/null; then #使用 curl 下载
+                ok "下载成功: $output"                           #打印日志
+                return 0                                     #成功返回
+            fi                                               #结束条件判断
+        fi                                                   #结束条件判断
+        warn "第 $attempt 次下载失败"                              #打印警告日志
+        if [[ $attempt -lt $max_attempts ]]; then            #如果还没到最大尝试次数
+            info "5秒后重试..."                                  #打印信息日志
+            sleep 5                                          #等待 5 秒
+        fi                                                   #结束条件判断
+        ((attempt++))                                        #增加尝试次数
+    done                                                     #结束循环
+    err "所有下载尝试都失败了"                                         #打印错误日志并退出
+}                                                            #结束函数定义
+
+select_github_proxy() {
+    print_title "选择 GitHub 代理"
+    echo "请根据您的网络环境选择一个合适的下载代理："
+    echo
+
+    select proxy_choice in "ghfast.top 镜像 (推荐)" "ghproxy.net 镜像" "不使用代理" "自定义代理"; do
+        case $proxy_choice in
+        "ghfast.top 镜像 (推荐)")
+            GITHUB_PROXY="https://ghfast.top/"
+            ok "已选择: ghfast.top 镜像"
+            break
+            ;;
+        "ghproxy.net 镜像")
+            GITHUB_PROXY="https://ghproxy.net/"
+            ok "已选择: ghproxy.net 镜像"
+            break
+            ;;
+        "不使用代理")
+            GITHUB_PROXY=""
+            ok "已选择: 不使用代理"
+            break
+            ;;
+        "自定义代理")
+            read -rp "请输入自定义 GitHub 代理 URL (如 ghfast.top/ 或 https://ghfast.top/, 必须以斜杠 / 结尾): " custom_proxy
+
+            # 自动加 https://（如果没有写协议）
+            if [[ "$custom_proxy" != http*://* ]]; then
+                custom_proxy="https://$custom_proxy"
+                warn "代理 URL 没有写协议，已自动加 https://"
+            fi
+
+            # 自动添加结尾斜杠
+            if [[ "$custom_proxy" != */ ]]; then
+                custom_proxy="${custom_proxy}/"
+                warn "代理 URL 没有以斜杠结尾，已自动添加斜杠"
+            fi
+
+            GITHUB_PROXY="$custom_proxy"
+            ok "已选择: 自定义代理 - $GITHUB_PROXY"
+            break
+            ;;
+        *)
+            warn "无效输入，使用默认代理"
+            GITHUB_PROXY="https://ghfast.top/"
+            ok "已选择: ghfast.top 镜像 (默认)"
+            break
+            ;;
+        esac
+    done
+}
+
+check_sudo() {
+    if [[ $EUID -eq 0 ]]; then
+        # 已经是root，不需要sudo
+        SUDO=""
+        ok "当前是 root 用户"
+    elif command_exists sudo; then
+        # 有sudo命令
+        SUDO="sudo"
+        ok "检测到 sudo 命令"
+    else
+        # 没有sudo
+        SUDO=""
+        warn "系统没有 sudo "
+    fi
+}
+
+# =============================================================================
+# 系统检测
+# =============================================================================
+detect_system() {        #定义函数
+    print_title "检测系统环境" #打印标题
+    ID="${ID:-}"
+    # 检测架构
+    ARCH=$(uname -m) #获取系统架构
+    case $ARCH in    # 根据架构打印信息
+    x86_64 | aarch64 | arm64)
+        ok "系统架构: $ARCH (支持)" #打印信息
+        ;;
+    *)
+        warn "架构 $ARCH 可能不被完全支持，继续尝试..." #打印警告
+        ;;
+    esac
+
+    # 检测操作系统
+    if [[ -f /etc/os-release ]]; then #如果文件存在
+        source /etc/os-release        #加载文件
+        ok "检测到系统: $NAME"             #打印信息
+    else                              # 否则
+        warn "无法检测具体系统版本"             #打印警告
+    fi                                #结束条件判断
+
+    # 检测包管理器
+    check_sudo
+    detect_package_manager
+} #结束函数定义
+
+# =============================================================================
+# 包管理器检测
+# =============================================================================
+detect_package_manager() { #定义函数
+    info "检测包管理器..."       #打印信息日志
+
+    local managers=( #定义包管理器数组
+        "apt:Debian/Ubuntu"
+        "pacman:Arch Linux"
+        "dnf:Fedora/RHEL/CentOS"
+        "yum:RHEL/CentOS (老版本)"
+        "zypper:openSUSE"
+        "apk:Alpine Linux"
+        "brew:macOS/Linux (Homebrew)"
+    ) #结束数组定义
+
+    for manager_info in "${managers[@]}"; do #循环遍历数组
+        local manager="${manager_info%%:*}"  #提取包管理器名称
+        local distro="${manager_info##*:}"   #提取发行版名称
+
+        if command_exists "$manager"; then       #如果包管理器存在
+            PKG_MANAGER="$manager"               #设置全局变量
+            DISTRO="$distro"                     #设置全局变量
+            ok "检测到包管理器: $PKG_MANAGER ($DISTRO)" #打印信息日志
+            return 0                             #成功返回
+        fi                                       #结束条件判断
+    done                                         #结束循环
+
+    err "未检测到支持的包管理器，请手动安装 git、curl/wget 和 python3" #打印错误日志并退出
+}                                                   #结束函数定义
+
+install_package() {    #定义函数
+    local package="$1" #获取参数
+
+    info "安装 $package..." #打印信息日志
+    case $PKG_MANAGER in  #根据包管理器选择安装命令
+    pacman)
+        $SUDO pacman -S --noconfirm "$package" #安装包
+        ;;
+    apt)
+        $SUDO apt update -qq 2>/dev/null || true #更新包列表
+        $SUDO apt install -y "$package"          #安装包
+        ;;
+    dnf)
+        # 如果是安装 screen，先确保 EPEL 已启用
+        if [[ "$package" == "screen" ]]; then
+            if ! dnf repolist enabled | grep -q epel; then
+                info "启用 EPEL 仓库以安装 screen..."
+                $SUDO dnf install -y epel-release 2>/dev/null || true
+            fi
+        fi
+        $SUDO dnf install -y "$package" #安装包
+        ;;
+    yum)
+        # 如果是安装 screen，先确保 EPEL 已启用
+        if [[ "$package" == "screen" ]]; then
+            if ! yum repolist enabled | grep -q epel; then
+                info "启用 EPEL 仓库以安装 screen..."
+                $SUDO yum install -y epel-release 2>/dev/null || true
+            fi
+        fi
+        $SUDO yum install -y "$package" #安装包
+        ;;
+    zypper)
+        $SUDO zypper install -y "$package" #安装包
+        ;;
+    apk)
+        $SUDO apk add gcc musl-dev linux-headers "$package" #安装包
+        ;;
+    brew)
+        $SUDO install "$package" #安装包
+        ;;
+    *)
+        warn "未知包管理器 $PKG_MANAGER，请手动安装 $package" #打印警告
+        ;;
+    esac #结束条件判断
+}        #结束函数定义
+
+#------------------------------------------------------------------------------
+
+# =============================================================================
+# 系统依赖安装
+# =============================================================================
+install_system_dependencies() { #定义函数
+    print_title "安装系统依赖"        #打印标题
+
+    local packages=("git" "python3" "screen" "tar" "findutils" "zip") #定义必需包数组
+
+    # 检查下载工具
+    if ! command_exists curl && ! command_exists wget; then #如果 curl 和 wget 都不存在
+        packages+=("curl")                                  #添加 curl 到数组
+    fi                                                      #结束条件判断
+
+    # Arch 系统特殊处理：添加 uv 到必需包数组
+    if [[ "$ID" == "arch" ]]; then
+        # 只有 Arch 才用包管理器安装 uv
+        packages+=("uv")
+        info "已将 uv 添加到 Arch 的必需安装包列表"
+    fi
+    if ! command_exists pip3 && ! command_exists pip; then #如果 pip3 和 pip 都不存在
+        case $PKG_MANAGER in                               #根据包管理器选择 pip 包名称
+        apt) packages+=("python3-pip") ;;                  # apt
+        pacman) packages+=("python-pip") ;;                # pacman
+        dnf | yum) packages+=("python3-pip") ;;            # dnf 和 yum
+        zypper) packages+=("python3-pip") ;;               # zypper
+        apk) packages+=("py3-pip") ;;                      # apk
+        brew) packages+=("pip3") ;;                        # brew
+        *) packages+=("python3-pip") ;;                    #默认
+        esac                                               #结束条件判断
+    fi
+    # 检查 Python 开发包
+    if ! command_exists python3-config; then
+        case $PKG_MANAGER in
+        apt) packages+=("python3-dev") ;;
+        pacman) packages+=("python") ;;
+        dnf | yum) packages+=("python3-devel") ;;
+        zypper) packages+=("python3-devel") ;;
+        apk) packages+=("python3-dev") ;;
+        brew) ;;
+        *) packages+=("python3-dev") ;;
+        esac
+    fi
+    # 检查 gcc/g++ 是否存在，如果都不存在则安装
+    if ! command_exists gcc || ! command_exists g++; then
+        case $PKG_MANAGER in
+        apt)
+            packages+=("build-essential") # 包含 gcc g++ make 等
+            ;;
+        pacman)
+            packages+=("base-devel") # Arch 基础开发包，包含 gcc g++
+            ;;
+        dnf | yum)
+            packages+=("gcc" "gcc-c++" "make")
+            ;;
+        zypper)
+            packages+=("gcc" "gcc-c++" "make")
+            ;;
+        apk)
+            packages+=("build-base") # Alpine 包含 gcc g++ make
+            ;;
+        brew)
+            packages+=("gcc")
+            ;;
+        *)
+            echo "未知包管理器，请手动安装 gcc/g++"
+            ;;
+        esac
+    fi
+
+    info "安装必需的系统包..."                                        #打印信息日志
+    for package in "${packages[@]}"; do                       #循环遍历包数组
+        if command_exists "${package/python3-pip/pip3}"; then #如果包已安装
+            ok "$package 已安装"                                 #打印信息日志
+        else                                                  #否则
+            install_package "$package"                        #安装包
+        fi                                                    #结束条件判断
+    done                                                      #结束循环
+
+    ok "系统依赖安装完成" #打印成功日志
+}                 #结束函数定义
+
+install_uv_environment() {
+    print_title "安装和配置 uv 环境"
+
+    if command_exists uv; then
+        ok "uv 已安装"
+    else
+        info "安装 uv..."
+        bash <(curl -sSL "${GITHUB_PROXY}https://github.com/Astriora/Antlia/raw/refs/heads/main/Script/UV/uv_install.sh") --GITHUB-URL "$GITHUB_PROXY"
+    fi
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+}
+
+clone_MoFox_Bot() {
+    local CLONE_URL="${GITHUB_PROXY}https://github.com/MoFox-Studio/MoFox_Bot.git" # 克隆源
+    if [ -d "$DEPLOY_DIR/MoFox_Bot" ]; then                                        # 如果目录已存在
+        warn "检测到 MoFox_Bot 文件夹已存在。是否删除重新克隆？(y/n)"                                 # 提示用户是否删除
+        read -rp "请输入选择 (y/n, 默认n): " del_choice                                   # 询问用户是否删除
+        del_choice=${del_choice:-n}                                                # 默认选择不删除
+        if [ "$del_choice" = "y" ] || [ "$del_choice" = "Y" ]; then                # 如果用户选择删除
+            rm -rf "$DEPLOY_DIR/MoFox_Bot"                                         # 删除MoFox_Bot目录
+            ok "已删除 MoFox_Bot 文件夹。"                                                # 提示用户已删除
+        else                                                                       # 如果用户选择不删除
+            warn "跳过 MoFox_Bot 仓库克隆。"                                              # 提示用户跳过克隆
+            return                                                                 # 结束函数
+        fi                                                                         # 结束删除选择
+    fi                                                                             # 如果目录不存在则继续克隆
+    info "克隆 MoFox_Bot 仓库"                                                         # 提示用户开始克隆
+    git clone --depth 1 "$CLONE_URL"                                               # 克隆仓库
+}                                                                                  # 克隆 仓库结束
+
+# 安装 Python 依赖
+install_python_dependencies() {
+    print_title "安装 Python 依赖"
+
+    # 配置 uv 镜像源
+    export UV_INDEX_URL="https://mirrors.ustc.edu.cn/pypi/simple/"
+    mkdir -p ~/.cache/uv
+    chown -R "$(whoami):$(whoami)" ~/.cache/uv
+
+    # 安装 MoFox_Bot 依赖
+    cd "$DEPLOY_DIR/MoFox_Bot" || err "无法进入 MoFox_Bot 目录"
+    info "同步 MoFox_Bot 依赖..."
+
+    attempt=1
+    while [[ $attempt -le 3 ]]; do
+        if uv sync --index-url "$UV_INDEX_URL"; then
+            ok "uv sync 成功"
+            break
+        else
+            warn "uv sync 失败,重试 $attempt/3"
+            ((attempt++))
+            sleep 5
+        fi
+    done
+
+    if [[ $attempt -gt 3 ]]; then
+        err "uv sync 多次失败"
+    fi
+
+    # 配置 MoFox_Bot
+    info "配置 MoFox_Bot..."
+    mkdir -p config
+    ok "已创建 config 文件夹"
+
+    # 复制配置文件
+    # 复制 .env
+    if [[ -f "template/template.env" ]]; then
+        cp "template/template.env" ".env"
+        # 自动同意 EULA
+        sed -i 's/^EULA_CONFIRMED=false/EULA_CONFIRMED=true/' .env
+        ok "已复制 .env 并自动同意 EULA"
+    else
+        warn "未找到 template/template.env"
+    fi
+
+    if [[ -f "template/model_config_template.toml" ]]; then
+        cp "template/model_config_template.toml" "config/model_config.toml"
+        ok "已复制 model_config.toml"
+    else
+        warn "未找到 template/model_config_template.toml"
+    fi
+
+    if [[ -f "template/bot_config_template.toml" ]]; then
+        cp "template/bot_config_template.toml" "config/bot_config.toml"
+        ok "已复制 bot_config_template.toml"
+    else
+        warn "未找到 template/bot_config_template.toml"
+    fi
+
+    ok "Python 依赖安装完成"
+}
+
+download_script() {
+    local DOWNLOAD_URL="${GITHUB_PROXY}https://raw.githubusercontent.com/Astriora/Antlia/refs/heads/main/Script/MoFox-Studio/mofox"
+    local TARGET_DIR="$LOCAL_BIN/MoFox_Bot"
+    local TARGET_FILE="$TARGET_DIR/mofox"
+
+    mkdir -p "$TARGET_DIR"
+
+    download_with_retry "$DOWNLOAD_URL" "$TARGET_FILE" || { err "下载失败"; }
+    chmod +x "$TARGET_FILE"
+    ok "mofox 脚本已下载到 $TARGET_FILE"
+
+    # 软链到 /usr/local/bin 方便全局调用
+    $SUDO ln -sf "$TARGET_FILE" /usr/local/bin/mofox
+
+    # 直接写 path.conf 到用户目录，不用初始化
+    echo "$DEPLOY_DIR" >"$TARGET_DIR/path.conf"
+    ok "路径配置文件已写入: $TARGET_DIR/path.conf"
+
+    ok "mofox 已准备就绪"
+}
+
+show_text() {
+    print_title "部署完成"
+
+    ok "MoFox_Bot 部署完成！"
+    info "部署路径: $DEPLOY_DIR"
+    info "MoFox_Bot 文件夹: $DEPLOY_DIR/MoFox_Bot"
+
+    echo
+    warn "请手动修改以下配置文件："
+    info " - $DEPLOY_DIR/MoFox_Bot/.env"
+    info " - $DEPLOY_DIR/MoFox_Bot/config/bot_config_template.toml"
+    info " - $DEPLOY_DIR/MoFox_Bot/config/model_config.toml"
+
+    echo
+    ok "完成配置后，可执行以下命令启动："
+    echo -e "  ${GREEN}mofox${RESET}"
+
+    echo
+}
+
+main() {
+    print_title "MoFox 2025.10.25"
+    detect_system
+
+    # 选择 GitHub 代理
+    select_github_proxy
+
+    # 安装系统依赖
+    install_system_dependencies
+
+    # 安装 uv
+    install_uv_environment
+
+    # 克隆仓库
+    clone_MoFox_Bot
+
+    # 安装 Python 依赖
+    install_python_dependencies
+    # 下载启动脚本
+    download_script
+    # 显示文字
+    show_text
+}
+
+# 执行主函数
+main

--- a/MoFox-install.sh
+++ b/MoFox-install.sh
@@ -456,8 +456,18 @@ download_script() {
     chmod +x "$TARGET_FILE"
     ok "mofox 脚本已下载到 $TARGET_FILE"
 
-    # 软链到 /usr/local/bin 方便全局调用
-    $SUDO ln -sf "$TARGET_FILE" /usr/local/bin/mofox
+    # 检查 /usr/local/bin 是否可写，否则软链到 ~/.local/bin
+    if [ -w /usr/local/bin ] || [ "$(id -u)" -eq 0 ]; then
+        $SUDO ln -sf "$TARGET_FILE" /usr/local/bin/mofox
+        ok "已创建软链到 /usr/local/bin/mofox"
+    else
+        # fallback to ~/.local/bin
+        local LOCAL_BIN_DIR="$HOME/.local/bin"
+        mkdir -p "$LOCAL_BIN_DIR"
+        ln -sf "$TARGET_FILE" "$LOCAL_BIN_DIR/mofox"
+        ok "无权限写入 /usr/local/bin，已创建软链到 $LOCAL_BIN_DIR/mofox"
+        ok "请确保 $LOCAL_BIN_DIR 已加入 PATH"
+    fi
 
     # 直接写 path.conf 到用户目录，不用初始化
     echo "$DEPLOY_DIR" >"$TARGET_DIR/path.conf"

--- a/mofox
+++ b/mofox
@@ -1,0 +1,270 @@
+#!/bin/bash
+set -euo pipefail
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+# =============================================================================
+# 配置部分
+# =============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATH_CONFIG_FILE="$HOME/.local/bin/MoFox_Bot/path.conf"
+
+
+# 颜色定义
+RESET='\033[0m'
+BOLD='\033[1m'
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+BLUE='\033[34m'
+CYAN='\033[36m'
+MAGENTA='\033[35m'
+CURRENT_USER=$(whoami)
+
+# =============================================================================
+# 日志函数
+# =============================================================================
+info() { echo -e "${BLUE}[INFO]${RESET} $1"; }
+success() { echo -e "${GREEN}[SUCCESS]${RESET} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${RESET} $1"; }
+error() { echo -e "${RED}[ERROR]${RESET} $1"; }
+
+print_line() {
+    echo -e "${CYAN}========================================================${RESET}"
+}
+
+print_title() {
+    echo ""
+    print_line
+    echo -e "${BOLD}${MAGENTA}$1${RESET}"
+    print_line
+}
+
+# =============================================================================
+# 路径初始化
+# =============================================================================
+init_paths() {
+    # 如果有 path.conf 文件,直接读取
+    if [ -f "$PATH_CONFIG_FILE" ]; then
+        DEPLOY_BASE=$(cat "$PATH_CONFIG_FILE" | tr -d '\n\r' | xargs)
+        info "从配置文件加载路径: $DEPLOY_BASE"
+    # 否则检测同级目录
+    elif [ -d "$SCRIPT_DIR/MoFox_Bot" ]; then
+        DEPLOY_BASE="$SCRIPT_DIR"
+        info "使用同级目录: $DEPLOY_BASE"
+    else
+        error "未找到 MoFox_Bot 目录,请使用 --init 参数配置路径"
+        echo "用法: $0 --init=/path/to/parent/dir"
+        exit 1
+    fi
+
+    DEPLOY_DIR="$DEPLOY_BASE/MoFox_Bot"
+}
+
+# =============================================================================
+# 工具函数
+# =============================================================================
+session_exists() {
+    screen -ls | grep -q "\.$1[[:space:]]"
+    return $?
+}
+
+check_service_status() {
+    local service=$1
+    if session_exists "$service"; then
+        echo -e "${GREEN}[运行中]${RESET}"
+        return 0
+    else
+        echo -e "${RED}[已停止]${RESET}"
+        return 1
+    fi
+}
+
+press_any_key() {
+    echo ""
+    read -n 1 -s -r -p "按任意键继续..."
+    echo ""
+}
+
+# =============================================================================
+# 函数
+# =============================================================================
+start_mofox() {
+    info "正在启动 MoFox_Bot..."
+
+    if session_exists "MoFox_Bot"; then
+        warn "MoFox_Bot 已在运行中"
+        return 1
+    fi
+    screen -dmS MoFox_Bot bash -c "cd \"$DEPLOY_DIR\" && uv run bot.py"
+
+    sleep 2
+
+    if session_exists "MoFox_Bot"; then
+        success "MoFox_Bot 启动成功"
+        return 0
+    else
+        error "MoFox_Bot 启动失败,请检查日志"
+        return 1
+    fi
+}
+
+stop_mofox() {
+    info "正在停止 MoFox_Bot..."
+
+    if ! session_exists "MoFox_Bot"; then
+        warn "MoFox_Bot 未运行"
+        return 1
+    fi
+
+    screen -S MoFox_Bot -X quit
+    sleep 1
+
+    if ! session_exists "MoFox_Bot"; then
+        success "MoFox_Bot 已停止"
+        return 0
+    else
+        error "MoFox_Bot 停止失败"
+        return 1
+    fi
+}
+
+attach_session() {
+    local session=$1
+    local name=${2:-$1}
+
+    if ! session_exists "$session"; then
+        error "$name 未运行,无法附加"
+        press_any_key
+        return 1
+    fi
+
+    info "正在附加到 $name 会话..."
+    info "使用 Ctrl+A 然后按 D 来分离会话"
+    sleep 2
+    screen -r "$session"
+}
+
+# =============================================================================
+# 菜单显示
+# =============================================================================
+show_menu() {
+    clear
+    print_title "MoFox_Bot  2025.10.25"
+
+    echo -e "${CYAN}系统信息:${RESET}"
+    echo -e "  用户: ${GREEN}$CURRENT_USER${RESET}"
+    echo -e "  时间: ${GREEN}$(date '+%Y-%m-%d %H:%M:%S')${RESET}"
+    echo -e "  路径: ${GREEN}$DEPLOY_BASE${RESET}"
+    echo ""
+
+    echo -e "${CYAN}服务状态:${RESET}"
+    echo -e "  MaiBot:                 $(check_service_status 'MoFox_Bot')"
+    echo ""
+
+    print_line
+    echo -e "${BOLD}${YELLOW}操作菜单:${RESET}"
+    print_line
+
+    echo -e "  ${BOLD}${GREEN}[1]${RESET} 启动 MoFox_Bot"
+    echo -e "  ${BOLD}${GREEN}[2]${RESET} 停止 MoFox_Bot"
+    echo -e "  ${BOLD}${GREEN}[3]${RESET} 附加 MoFox_Bot 会话"
+    echo -e ""
+    echo -e "  ${BOLD}${GREEN}[4]${RESET} 前台启动 MoFox_Bot "
+    echo -e "  ${BOLD}${GREEN}[5]${RESET} 更新 MoFox_Bot"
+    echo ""
+    echo -e "  ${BOLD}${GREEN}[0]${RESET} 退出脚本"
+
+    print_line
+    echo ""
+    echo -ne "${BOLD}${YELLOW}请选择操作 [0-8]: ${RESET}"
+}
+
+# =============================================================================
+# 主程序
+# =============================================================================
+main() {
+    # 处理 --init 参数
+    if [[ $1 == --init=* ]]; then
+        local init_path="${1#*=}"
+
+        # 验证路径
+        if [ ! -d "$init_path/MoFox_Bot" ]; then
+            error "未找到 MoFox_Bot 目录: $init_path/MoFox_Bot"
+            exit 1
+        fi
+
+      # 写入配置文件
+        echo "$init_path" >"$PATH_CONFIG_FILE"
+        success "路径配置成功: $init_path"
+        success "配置文件: $PATH_CONFIG_FILE"
+        exit 0
+    fi
+
+
+    # 初始化路径
+    init_paths
+
+    # 主循环
+    while true; do
+        show_menu
+        read -r choice
+
+        case $choice in
+        1) start_mofox ;;
+        2) stop_mofox ;;
+        3) attach_session "MoFox_Bot" && press_any_key ;;
+        4)
+            print_title "前台启动 MoFox_Bot"
+            # 如果已运行先停止
+            if session_exists "MoFox_Bot"; then
+                stop_mofox
+            fi
+            cd "$DEPLOY_DIR" || {
+                error "无法进入目录 $DEPLOY_DIR"
+                press_any_key
+                continue
+            }
+            echo -e "${GREEN}前台启动 MaiBot,使用 Ctrl+C 停止${RESET}"
+            uv run bot.py
+            press_any_key
+            ;;
+
+        5)
+            print_title "更新 MoFox_Bot"
+            cd "$DEPLOY_DIR" || {
+                error "无法进入目录 $DEPLOY_DIR"
+                press_any_key
+                continue
+            }
+
+            if ! git pull --ff-only; then
+                error "Git 更新失败"
+                press_any_key
+                continue
+            fi
+
+            if ! uv sync --upgrade \
+                --index https://mirrors.huaweicloud.com/repository/pypi/simple/ \
+                --index https://pypi.org/simple/; then
+                error "依赖更新失败"
+                press_any_key
+                continue
+            fi
+
+            press_any_key
+            ;;
+        114514) echo "兄弟兄弟能不能给我的项目点一个star https://github.com/Astriora/Antlia 我可以给你发腿照" && press_any_key ;;
+        0)
+            exit 0
+            ;;
+        *)
+            error "无效选项,请重新选择"
+            sleep 2
+            ;;
+        esac
+    done
+}
+
+# 运行主程序
+main "${1:-}"
+

--- a/mofox
+++ b/mofox
@@ -8,7 +8,6 @@ export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATH_CONFIG_FILE="$HOME/.local/bin/MoFox_Bot/path.conf"
 
-
 # 颜色定义
 RESET='\033[0m'
 BOLD='\033[1m'
@@ -29,242 +28,239 @@ warn() { echo -e "${YELLOW}[WARN]${RESET} $1"; }
 error() { echo -e "${RED}[ERROR]${RESET} $1"; }
 
 print_line() {
-    echo -e "${CYAN}========================================================${RESET}"
+	echo -e "${CYAN}========================================================${RESET}"
 }
 
 print_title() {
-    echo ""
-    print_line
-    echo -e "${BOLD}${MAGENTA}$1${RESET}"
-    print_line
+	echo ""
+	print_line
+	echo -e "${BOLD}${MAGENTA}$1${RESET}"
+	print_line
 }
 
 # =============================================================================
 # 路径初始化
 # =============================================================================
 init_paths() {
-    # 如果有 path.conf 文件,直接读取
-    if [ -f "$PATH_CONFIG_FILE" ]; then
-        DEPLOY_BASE=$(cat "$PATH_CONFIG_FILE" | tr -d '\n\r' | xargs)
-        info "从配置文件加载路径: $DEPLOY_BASE"
-    # 否则检测同级目录
-    elif [ -d "$SCRIPT_DIR/MoFox_Bot" ]; then
-        DEPLOY_BASE="$SCRIPT_DIR"
-        info "使用同级目录: $DEPLOY_BASE"
-    else
-        error "未找到 MoFox_Bot 目录,请使用 --init 参数配置路径"
-        echo "用法: $0 --init=/path/to/parent/dir"
-        exit 1
-    fi
+	# 如果有 path.conf 文件,直接读取
+	if [ -f "$PATH_CONFIG_FILE" ]; then
+		DEPLOY_BASE=$(cat "$PATH_CONFIG_FILE" | tr -d '\n\r' | xargs)
+		info "从配置文件加载路径: $DEPLOY_BASE"
+	# 否则检测同级目录
+	elif [ -d "$SCRIPT_DIR/MoFox_Bot" ]; then
+		DEPLOY_BASE="$SCRIPT_DIR"
+		info "使用同级目录: $DEPLOY_BASE"
+	else
+		error "未找到 MoFox_Bot 目录,请使用 --init 参数配置路径"
+		echo "用法: $0 --init=/path/to/parent/dir"
+		exit 1
+	fi
 
-    DEPLOY_DIR="$DEPLOY_BASE/MoFox_Bot"
+	DEPLOY_DIR="$DEPLOY_BASE/MoFox_Bot"
 }
 
 # =============================================================================
 # 工具函数
 # =============================================================================
 session_exists() {
-    screen -ls | grep -q "\.$1[[:space:]]"
-    return $?
+	screen -ls | grep -q "\.$1[[:space:]]"
+	return $?
 }
 
 check_service_status() {
-    local service=$1
-    if session_exists "$service"; then
-        echo -e "${GREEN}[运行中]${RESET}"
-        return 0
-    else
-        echo -e "${RED}[已停止]${RESET}"
-        return 1
-    fi
+	local service=$1
+	if session_exists "$service"; then
+		echo -e "${GREEN}[运行中]${RESET}"
+		return 0
+	else
+		echo -e "${RED}[已停止]${RESET}"
+		return 1
+	fi
 }
 
 press_any_key() {
-    echo ""
-    read -n 1 -s -r -p "按任意键继续..."
-    echo ""
+	echo ""
+	read -n 1 -s -r -p "按任意键继续..."
+	echo ""
 }
 
 # =============================================================================
 # 函数
 # =============================================================================
 start_mofox() {
-    info "正在启动 MoFox_Bot..."
+	info "正在启动 MoFox_Bot..."
 
-    if session_exists "MoFox_Bot"; then
-        warn "MoFox_Bot 已在运行中"
-        return 1
-    fi
-    screen -dmS MoFox_Bot bash -c "cd \"$DEPLOY_DIR\" && uv run bot.py"
+	if session_exists "MoFox_Bot"; then
+		warn "MoFox_Bot 已在运行中"
+		return 1
+	fi
+	screen -dmS MoFox_Bot bash -c "cd \"$DEPLOY_DIR\" && uv run bot.py"
 
-    sleep 2
+	sleep 2
 
-    if session_exists "MoFox_Bot"; then
-        success "MoFox_Bot 启动成功"
-        return 0
-    else
-        error "MoFox_Bot 启动失败,请检查日志"
-        return 1
-    fi
+	if session_exists "MoFox_Bot"; then
+		success "MoFox_Bot 启动成功"
+		return 0
+	else
+		error "MoFox_Bot 启动失败,请检查日志"
+		return 1
+	fi
 }
 
 stop_mofox() {
-    info "正在停止 MoFox_Bot..."
+	info "正在停止 MoFox_Bot..."
 
-    if ! session_exists "MoFox_Bot"; then
-        warn "MoFox_Bot 未运行"
-        return 1
-    fi
+	if ! session_exists "MoFox_Bot"; then
+		warn "MoFox_Bot 未运行"
+		return 1
+	fi
 
-    screen -S MoFox_Bot -X quit
-    sleep 1
+	screen -S MoFox_Bot -X quit
+	sleep 1
 
-    if ! session_exists "MoFox_Bot"; then
-        success "MoFox_Bot 已停止"
-        return 0
-    else
-        error "MoFox_Bot 停止失败"
-        return 1
-    fi
+	if ! session_exists "MoFox_Bot"; then
+		success "MoFox_Bot 已停止"
+		return 0
+	else
+		error "MoFox_Bot 停止失败"
+		return 1
+	fi
 }
 
 attach_session() {
-    local session=$1
-    local name=${2:-$1}
+	local session=$1
+	local name=${2:-$1}
 
-    if ! session_exists "$session"; then
-        error "$name 未运行,无法附加"
-        press_any_key
-        return 1
-    fi
+	if ! session_exists "$session"; then
+		error "$name 未运行,无法附加"
+		press_any_key
+		return 1
+	fi
 
-    info "正在附加到 $name 会话..."
-    info "使用 Ctrl+A 然后按 D 来分离会话"
-    sleep 2
-    screen -r "$session"
+	info "正在附加到 $name 会话..."
+	info "使用 Ctrl+A 然后按 D 来分离会话"
+	sleep 2
+	screen -r "$session"
 }
 
 # =============================================================================
 # 菜单显示
 # =============================================================================
 show_menu() {
-    clear
-    print_title "MoFox_Bot  2025.10.25"
+	clear
+	print_title "MoFox_Bot  2025.10.25"
 
-    echo -e "${CYAN}系统信息:${RESET}"
-    echo -e "  用户: ${GREEN}$CURRENT_USER${RESET}"
-    echo -e "  时间: ${GREEN}$(date '+%Y-%m-%d %H:%M:%S')${RESET}"
-    echo -e "  路径: ${GREEN}$DEPLOY_BASE${RESET}"
-    echo ""
+	echo -e "${CYAN}系统信息:${RESET}"
+	echo -e "  用户: ${GREEN}$CURRENT_USER${RESET}"
+	echo -e "  时间: ${GREEN}$(date '+%Y-%m-%d %H:%M:%S')${RESET}"
+	echo -e "  路径: ${GREEN}$DEPLOY_BASE${RESET}"
+	echo ""
 
-    echo -e "${CYAN}服务状态:${RESET}"
-    echo -e "  MaiBot:                 $(check_service_status 'MoFox_Bot')"
-    echo ""
+	echo -e "${CYAN}服务状态:${RESET}"
+	echo -e "  MaiBot:                 $(check_service_status 'MoFox_Bot')"
+	echo ""
 
-    print_line
-    echo -e "${BOLD}${YELLOW}操作菜单:${RESET}"
-    print_line
+	print_line
+	echo -e "${BOLD}${YELLOW}操作菜单:${RESET}"
+	print_line
 
-    echo -e "  ${BOLD}${GREEN}[1]${RESET} 启动 MoFox_Bot"
-    echo -e "  ${BOLD}${GREEN}[2]${RESET} 停止 MoFox_Bot"
-    echo -e "  ${BOLD}${GREEN}[3]${RESET} 附加 MoFox_Bot 会话"
-    echo -e ""
-    echo -e "  ${BOLD}${GREEN}[4]${RESET} 前台启动 MoFox_Bot "
-    echo -e "  ${BOLD}${GREEN}[5]${RESET} 更新 MoFox_Bot"
-    echo ""
-    echo -e "  ${BOLD}${GREEN}[0]${RESET} 退出脚本"
+	echo -e "  ${BOLD}${GREEN}[1]${RESET} 启动 MoFox_Bot"
+	echo -e "  ${BOLD}${GREEN}[2]${RESET} 停止 MoFox_Bot"
+	echo -e "  ${BOLD}${GREEN}[3]${RESET} 附加 MoFox_Bot 会话"
+	echo -e ""
+	echo -e "  ${BOLD}${GREEN}[4]${RESET} 前台启动 MoFox_Bot "
+	echo -e "  ${BOLD}${GREEN}[5]${RESET} 更新 MoFox_Bot"
+	echo ""
+	echo -e "  ${BOLD}${GREEN}[0]${RESET} 退出脚本"
 
-    print_line
-    echo ""
-    echo -ne "${BOLD}${YELLOW}请选择操作 [0-8]: ${RESET}"
+	print_line
+	echo ""
+	echo -ne "${BOLD}${YELLOW}请选择操作 [0-8]: ${RESET}"
 }
 
 # =============================================================================
 # 主程序
 # =============================================================================
 main() {
-    # 处理 --init 参数
-    if [[ $1 == --init=* ]]; then
-        local init_path="${1#*=}"
+	# 处理 --init 参数
+	if [[ $1 == --init=* ]]; then
+		local init_path="${1#*=}"
 
-        # 验证路径
-        if [ ! -d "$init_path/MoFox_Bot" ]; then
-            error "未找到 MoFox_Bot 目录: $init_path/MoFox_Bot"
-            exit 1
-        fi
+		# 验证路径
+		if [ ! -d "$init_path/MoFox_Bot" ]; then
+			error "未找到 MoFox_Bot 目录: $init_path/MoFox_Bot"
+			exit 1
+		fi
 
-      # 写入配置文件
-        echo "$init_path" >"$PATH_CONFIG_FILE"
-        success "路径配置成功: $init_path"
-        success "配置文件: $PATH_CONFIG_FILE"
-        exit 0
-    fi
+		# 写入配置文件
+		echo "$init_path" >"$PATH_CONFIG_FILE"
+		success "路径配置成功: $init_path"
+		success "配置文件: $PATH_CONFIG_FILE"
+		exit 0
+	fi
 
+	# 初始化路径
+	init_paths
 
-    # 初始化路径
-    init_paths
+	# 主循环
+	while true; do
+		show_menu
+		read -r choice
 
-    # 主循环
-    while true; do
-        show_menu
-        read -r choice
+		case $choice in
+		1) start_mofox ;;
+		2) stop_mofox ;;
+		3) attach_session "MoFox_Bot" && press_any_key ;;
+		4)
+			print_title "前台启动 MoFox_Bot"
+			# 如果已运行先停止
+			if session_exists "MoFox_Bot"; then
+				stop_mofox
+			fi
+			cd "$DEPLOY_DIR" || {
+				error "无法进入目录 $DEPLOY_DIR"
+				press_any_key
+				continue
+			}
+			echo -e "${GREEN}前台启动 MaiBot,使用 Ctrl+C 停止${RESET}"
+			uv run bot.py
+			press_any_key
+			;;
 
-        case $choice in
-        1) start_mofox ;;
-        2) stop_mofox ;;
-        3) attach_session "MoFox_Bot" && press_any_key ;;
-        4)
-            print_title "前台启动 MoFox_Bot"
-            # 如果已运行先停止
-            if session_exists "MoFox_Bot"; then
-                stop_mofox
-            fi
-            cd "$DEPLOY_DIR" || {
-                error "无法进入目录 $DEPLOY_DIR"
-                press_any_key
-                continue
-            }
-            echo -e "${GREEN}前台启动 MaiBot,使用 Ctrl+C 停止${RESET}"
-            uv run bot.py
-            press_any_key
-            ;;
+		5)
+			print_title "更新 MoFox_Bot"
+			cd "$DEPLOY_DIR" || {
+				error "无法进入目录 $DEPLOY_DIR"
+				press_any_key
+				continue
+			}
 
-        5)
-            print_title "更新 MoFox_Bot"
-            cd "$DEPLOY_DIR" || {
-                error "无法进入目录 $DEPLOY_DIR"
-                press_any_key
-                continue
-            }
+			if ! git pull --ff-only; then
+				error "Git 更新失败"
+				press_any_key
+				continue
+			fi
 
-            if ! git pull --ff-only; then
-                error "Git 更新失败"
-                press_any_key
-                continue
-            fi
+			if ! uv sync --upgrade \
+				--index https://mirrors.huaweicloud.com/repository/pypi/simple/ \
+				--index https://pypi.org/simple/; then
+				error "依赖更新失败"
+				press_any_key
+				continue
+			fi
 
-            if ! uv sync --upgrade \
-                --index https://mirrors.huaweicloud.com/repository/pypi/simple/ \
-                --index https://pypi.org/simple/; then
-                error "依赖更新失败"
-                press_any_key
-                continue
-            fi
-
-            press_any_key
-            ;;
-        114514) echo "兄弟兄弟能不能给我的项目点一个star https://github.com/Astriora/Antlia 我可以给你发腿照" && press_any_key ;;
-        0)
-            exit 0
-            ;;
-        *)
-            error "无效选项,请重新选择"
-            sleep 2
-            ;;
-        esac
-    done
+			press_any_key
+			;;
+		0)
+			exit 0
+			;;
+		*)
+			error "无效选项,请重新选择"
+			sleep 2
+			;;
+		esac
+	done
 }
 
 # 运行主程序
 main "${1:-}"
-


### PR DESCRIPTION
维护人员 您好 
我为您的项目提供了部署脚本
该脚本是使用纯shell写的 包括以下几个部署流程
定义全局变量
检查sudo和是否是root用户
检测软件包管理器
选择GitHub克隆源
安装依赖
使用我维护的脚本安装uv支持GitHub代理
克隆项目
同步依赖
复制配置文件
下载启动脚本初始化
打印部署完成的输出脚本结束
启动脚本使用screen会话管理使用简单 支持很多Linux发行版 除（termux安装proot容器外 因为proot的环境太特殊了导致mofox后台启动后 找不到screen会话 这个是没有办法的 安卓的环境太特殊了）
提供简单的菜单 前台后台启动 停止附加screen会话 更新mofox使用git pull和同步uv依赖 退出脚本
该脚本已经过测试 
[archlinux-20251025-testlog.txt](https://github.com/user-attachments/files/23164625/archlinux-20251025-testlog.txt)
 
[ubuntu-20251025-testlog.txt](https://github.com/user-attachments/files/23164626/ubuntu-20251025-testlog.txt)

测试均正常 代码透明 无恶意代码
我会给脚本提供提供维护更新
望通过谢谢
使用命令您可以使用
```bash
bash <(curl -sSL https://raw.githubusercontent.com/Astriora/Antlia/refs/heads/main/Script/MoFox-Studio/MoFox-install.sh)
```
来使用这个脚本
您可以把脚本的raw链接修改为您的仓库的链接
期待您的反馈，谢谢！

## Summary by Sourcery

Automate MoFox_Bot deployment and lifecycle management using pure shell scripts with cross-distro support and GitHub proxy selection.

New Features:
- Add MoFox-install.sh to automate environment detection, dependency installation, repository cloning, and configuration for MoFox_Bot across multiple Linux distributions
- Add mofox CLI script to ~/.local/bin with a global symlink for easy management (start, stop, update) of the bot via screen sessions